### PR TITLE
Some docker fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ Streamline a test deployment environment.
 ```
 git clone https://github.com/Kitware/hpccloud-services.git
 cd hpccloud-services
+```
+
+If you have run the system before, you may need to re-pull the stack of images:
+
+```
+docker-compose pull
+```
+
+And then you can bring the system up with:
+
+```
 docker-compose up -d
 ```
 

--- a/ansible/roles/girder/tasks/dev.yml
+++ b/ansible/roles/girder/tasks/dev.yml
@@ -111,28 +111,28 @@
 - name: Set 1st cluster to compute cluster from output
   set_fact:
     compute_cluster: "{{ clusters.gc_return[0] }}"
-  when: 
+  when:
     - clusters.gc_return|length == 2
     - clusters.gc_return[0].name == "compute"
 
 - name: Set 1st cluster to visualize cluster from output
   set_fact:
     visualize_cluster: "{{ clusters.gc_return[0] }}"
-  when: 
+  when:
     - clusters.gc_return|length == 2
     - clusters.gc_return[0].name == "visualize"
 
 - name: Set 2nd cluster to compute cluster from output
   set_fact:
     compute_cluster: "{{ clusters.gc_return[1] }}"
-  when: 
+  when:
     - clusters.gc_return|length == 2
     - clusters.gc_return[1].name == "compute"
 
 - name: Set 2nd cluster to visualize cluster from output
   set_fact:
     visualize_cluster: "{{ clusters.gc_return[1] }}"
-  when: 
+  when:
     - clusters.gc_return|length == 2
     - clusters.gc_return[1].name == "visualize"
 
@@ -165,6 +165,12 @@
 - name: Set compute_cluster from output
   set_fact:
     compute_cluster: "{{ compute_cluster.gc_return }}"
+
+- name: Wait until compute is ready for ssh connection
+  wait_for:
+    host=compute
+    port=22
+    delay=5
 
 - name: Add public key to authorize_keys on compute cluster
   authorized_key:
@@ -223,6 +229,12 @@
 - name: Set visualize_cluster from output
   set_fact:
     visualize_cluster: "{{ visualize_cluster.gc_return }}"
+
+- name: Wait until visualize is ready for ssh connection
+  wait_for:
+    host=visualize
+    port=22
+    delay=5
 
 - name: Add public key to authorize_keys on visualize cluster
   authorized_key:

--- a/docker/celery-pyfr/Dockerfile
+++ b/docker/celery-pyfr/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && \
                  h5py
 
 # Install PyFR 1.8.0
-RUN wget -q -O PyFR-1.8.0.zip http://www.pyfr.org/download/PyFR-1.8.0.zip && \
+RUN wget -q -O PyFR-1.8.0.zip https://github.com/PyFR/PyFR/archive/v1.8.0.zip && \
     unzip -qq PyFR-1.8.0.zip && \
     cd PyFR-1.8.0 && \
     python3 setup.py install && \

--- a/docker/compute-pyfr/Dockerfile
+++ b/docker/compute-pyfr/Dockerfile
@@ -37,7 +37,7 @@ RUN pip3 install appdirs \
                  h5py
 
 # Install PyFR 1.8.0
-RUN wget -q -O PyFR-1.8.0.zip http://www.pyfr.org/download/PyFR-1.8.0.zip && \
+RUN wget -q -O PyFR-1.8.0.zip https://github.com/PyFR/PyFR/archive/v1.8.0.zip && \
     unzip -qq PyFR-1.8.0.zip && \
     cd PyFR-1.8.0 && \
     python3 setup.py install

--- a/docker/visualize-egl/Dockerfile
+++ b/docker/visualize-egl/Dockerfile
@@ -43,17 +43,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         wget && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install mako
+    python2 -m pip install mako
 
 RUN mkdir -p /home/demo/cmake/3.13.4 && \
-    mkdir -p /home/demo/pvsb/build
+    mkdir -p /home/demo/pvsb/longerpathlongerpathlongerpathlongerpath/build
 
 COPY ./docker/visualize-egl/cmake/Docker-Ubuntu-18_04.cmake /home/demo/pvsb/Docker-Ubuntu-18_04.cmake
 
 # Get CMake, then clone the ParaView superbuild project
 RUN cd /home/demo/cmake/3.13.4 && \
     curl -L https://cmake.org/files/v3.13/cmake-3.13.4-Linux-x86_64.tar.gz | tar --strip-components=1 -xzv && \
-    cd /home/demo/pvsb && \
+    cd /home/demo/pvsb/longerpathlongerpathlongerpathlongerpath && \
     git clone --recursive ${SUPERBUILD_REPO} src && \
     cd src && git checkout ${SUPERBUILD_TAG} && git submodule update && cd .. && \
     cd build && \

--- a/docker/visualize-egl/cmake/Docker-Ubuntu-18_04.cmake
+++ b/docker/visualize-egl/cmake/Docker-Ubuntu-18_04.cmake
@@ -20,6 +20,7 @@ set(EGL_opengl_LIBRARY "/usr/lib/x86_64-linux-gnu/libOpenGL.so" CACHE FILEPATH "
 
 # Turn off index as it doesn't seem to work
 set(ENABLE_nvidiaindex OFF CACHE BOOL "")
+set(ENABLE_visrtx OFF CACHE BOOL "")
 
 set(PV_CMAKE_ARGS "-DOpenGL_GL_PREFERENCE:STRING=GLVND")
 
@@ -46,7 +47,10 @@ set(PV_CMAKE_ARGS "${PV_CMAKE_ARGS};-DPython2_EXECUTABLE:FILEPATH=/usr/bin/pytho
 set(PV_CMAKE_ARGS "${PV_CMAKE_ARGS};-DPython2_LIBRARY_RELEASE:FILEPATH=/usr/lib/x86_64-linux-gnu/libpython2.7.so")
 set(PV_CMAKE_ARGS "${PV_CMAKE_ARGS};-DPython2_INCLUDE_DIR:PATH=/usr/include/python2.7")
 
-set(USE_SYSTEM_python ON CACHE BOOL "")
+set(ENABLE_python2 ON CACHE BOOL "")
+set(USE_SYSTEM_python2 ON CACHE BOOL "")
+set(ENABLE_python3 OFF CACHE BOOL "")
+set(USE_SYSTEM_python3 OFF CACHE BOOL "")
 set(USE_SYSTEM_pythonsetuptools ON CACHE BOOL "")
 set(ENABLE_matplotlib ON CACHE BOOL "")
 set(ENABLE_scipy ON CACHE BOOL "")

--- a/docker/visualize-osmesa/Dockerfile
+++ b/docker/visualize-osmesa/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install ParaView 5.6.0
-RUN wget -q -O ParaView-5.6.0.tar.xz https://www.paraview.org/files/v5.6/ParaView-5.6.0-osmesa-MPI-Linux-64bit.tar.xz && \
-    tar xf ParaView-5.6.0.tar.xz && \
-    mv ParaView-5.6.0-osmesa-MPI-Linux-64bit ParaView
+RUN wget -q -O ParaView-5.6.1.tar.xz https://www.paraview.org/files/v5.6/ParaView-5.6.1-osmesa-MPI-Linux-64bit.tar.xz && \
+    tar xf ParaView-5.6.1.tar.xz && \
+    mv ParaView-5.6.1-osmesa-MPI-Linux-64bit ParaView
 
 EXPOSE 9090

--- a/image-pull-push.sh
+++ b/image-pull-push.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Uncomment the first two blocks to remove all hpccloud-services
+# images and re-pull the latest versions.
+
+# docker image rm kitware/hpccloud:bionic-python
+# docker image rm kitware/hpccloud:nvidia-bionic-python
+# docker image rm kitware/hpccloud:sge-ssh
+# docker image rm kitware/hpccloud:nvidia-sge-ssh
+# docker image rm kitware/hpccloud:visualize-osmesa
+# docker image rm kitware/hpccloud:visualize-egl
+# docker image rm kitware/hpccloud:compute-pyfr
+# docker image rm kitware/hpccloud:nvidia-compute-pyfr
+# docker image rm kitware/hpccloud:celery
+# docker image rm kitware/hpccloud:celery-pyfr
+# docker image rm kitware/hpccloud:ansible
+# docker image rm kitware/hpccloud:girder
+# docker image rm kitware/hpccloud:nginx
+
+# docker pull kitware/hpccloud:bionic-python
+# docker pull kitware/hpccloud:nvidia-bionic-python
+# docker pull kitware/hpccloud:sge-ssh
+# docker pull kitware/hpccloud:nvidia-sge-ssh
+# docker pull kitware/hpccloud:visualize-osmesa
+# docker pull kitware/hpccloud:visualize-egl
+# docker pull kitware/hpccloud:compute-pyfr
+# docker pull kitware/hpccloud:nvidia-compute-pyfr
+# docker pull kitware/hpccloud:celery
+# docker pull kitware/hpccloud:celery-pyfr
+# docker pull kitware/hpccloud:ansible
+# docker pull kitware/hpccloud:girder
+# docker pull kitware/hpccloud:nginx
+
+# Uncomment the last block to push all the hpccloud-services
+# tagged images.
+
+docker push kitware/hpccloud:bionic-python
+docker push kitware/hpccloud:nvidia-bionic-python
+docker push kitware/hpccloud:sge-ssh
+docker push kitware/hpccloud:nvidia-sge-ssh
+docker push kitware/hpccloud:visualize-osmesa
+docker push kitware/hpccloud:visualize-egl
+docker push kitware/hpccloud:compute-pyfr
+docker push kitware/hpccloud:nvidia-compute-pyfr
+docker push kitware/hpccloud:celery
+docker push kitware/hpccloud:celery-pyfr
+docker push kitware/hpccloud:ansible
+docker push kitware/hpccloud:girder
+docker push kitware/hpccloud:nginx

--- a/rebuild-stack.sh
+++ b/rebuild-stack.sh
@@ -41,8 +41,7 @@ docker build --rm --no-cache --file docker/visualize-osmesa/Dockerfile -t kitwar
 #----------------------------------------------------------------------------
 
 echo -e "\n\n\nBuilding kitware/hpccloud:visualize-egl \n\n\n"
-# docker build --rm --no-cache --file docker/visualize-egl/Dockerfile --build-arg PARAVIEW_TAG=v5.6.1 --build-arg SUPERBUILD_TAG=v5.6.1 -t kitware/hpccloud:visualize-egl .
-docker build --rm --no-cache --file docker/visualize-egl/Dockerfile -t kitware/hpccloud:visualize-egl .
+docker build --rm --no-cache --file docker/visualize-egl/Dockerfile --build-arg PARAVIEW_TAG=v5.6.1 --build-arg SUPERBUILD_TAG=v5.6.1 -t kitware/hpccloud:visualize-egl .
 
 #----------------------------------------------------------------------------
 #                                compute-pyfr
@@ -58,11 +57,11 @@ docker build --rm --no-cache --file docker/compute-pyfr/Dockerfile --build-arg B
 #                                compute-parflow
 #----------------------------------------------------------------------------
 
-echo -e "\n\n\nBuilding kitware/hpccloud:compute-parflow \n\n\n"
-docker build --rm --no-cache --file docker/compute-parflow/Dockerfile -t kitware/hpccloud:compute-parflow .
+# echo -e "\n\n\nBuilding kitware/hpccloud:compute-parflow \n\n\n"
+# docker build --rm --no-cache --file docker/compute-parflow/Dockerfile -t kitware/hpccloud:compute-parflow .
 
-echo -e "\n\n\nBuilding kitware/hpccloud:nvidia-compute-parflow \n\n\n"
-docker build --rm --no-cache --file docker/compute-parflow/Dockerfile --build-arg BASE_IMAGE=kitware/hpccloud:nvidia-sge-ssh -t kitware/hpccloud:nvidia-compute-parflow .
+# echo -e "\n\n\nBuilding kitware/hpccloud:nvidia-compute-parflow \n\n\n"
+# docker build --rm --no-cache --file docker/compute-parflow/Dockerfile --build-arg BASE_IMAGE=kitware/hpccloud:nvidia-sge-ssh -t kitware/hpccloud:nvidia-compute-parflow .
 
 #----------------------------------------------------------------------------
 #                                  celery
@@ -82,8 +81,8 @@ docker build --rm --no-cache --file docker/celery-pyfr/Dockerfile -t kitware/hpc
 #                                celery-parflow
 #----------------------------------------------------------------------------
 
-echo -e "\n\n\nBuilding kitware/hpccloud:celery-parflow \n\n\n"
-docker build --rm --no-cache --file docker/celery-parflow/Dockerfile -t kitware/hpccloud:celery-parflow .
+# echo -e "\n\n\nBuilding kitware/hpccloud:celery-parflow \n\n\n"
+# docker build --rm --no-cache --file docker/celery-parflow/Dockerfile -t kitware/hpccloud:celery-parflow .
 
 #----------------------------------------------------------------------------
 #                                  ansible


### PR DESCRIPTION
Get demo stack to work again, including:

- fix for broken pyfr downloads
- update visualize cluster nodes to pv v5.6.1
- wait for port 22 before copying auth keys to compute and visualize
- add a shell script to re-pull images (or push them)