### PR TITLE
Tag 4 month old rabbitmq because latest breaks hpccloud

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
      - GIRDER_PORT=8080
 
   rabbitmq:
-    image: rabbitmq
+    image: kitware/hpccloud:rabbitmq
     networks:
       - hc
 


### PR DESCRIPTION
using rabbitmq@sha256:db558ab49aa234c3ea6c365a4e244126a832ad050c525992ecb53176549d9c7f which was pushed to kitware/hpccloud:rabbitmq