### PR TITLE
Upgrade dependency versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 version: '2.3'
 services:
   mongodb:
-    image: mongo:3.6
+    image: mongo:4.2
     networks:
       - hc
     volumes:

--- a/docker/celery-parflow/Dockerfile
+++ b/docker/celery-parflow/Dockerfile
@@ -38,13 +38,13 @@ ENV HYPRE_DIR=/hypre
 ENV PARFLOW_DIR=/parflow
 
 # Install hypre
-RUN wget -q https://github.com/hypre-space/hypre/archive/v2.17.0.tar.gz && \
-    tar xf v2.17.0.tar.gz && \
-    cd hypre-2.17.0/src && \
+RUN wget -q https://github.com/hypre-space/hypre/archive/v2.18.2.tar.gz && \
+    tar xf v2.18.2.tar.gz && \
+    cd hypre-2.18.2/src && \
     ./configure --prefix=/hypre --with-MPI && \
     make install && \
     cd / && \
-    rm -fr hypre-2.17.0 v2.17.0.tar.gz
+    rm -fr hypre-2.18.2 v2.18.2.tar.gz
 
 # Intall parflow
 RUN git clone -b master --single-branch https://github.com/parflow/parflow.git /parflow-tmp

--- a/docker/celery-pyfr/Dockerfile
+++ b/docker/celery-pyfr/Dockerfile
@@ -1,9 +1,9 @@
-# Docker file for celery + PyFR 1.8.0
+# Docker file for celery + PyFR 1.9.0
 
 FROM kitware/hpccloud:celery
 LABEL maintainer="patrick.oleary@kitware.com" \
       version="1.0" \
-      pyfr.version="1.8.0"
+      pyfr.version="1.9.0"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -35,11 +35,11 @@ RUN apt-get update && \
                  mpi4py \
                  h5py
 
-# Install PyFR 1.8.0
-RUN wget -q -O PyFR-1.8.0.zip https://github.com/PyFR/PyFR/archive/v1.8.0.zip && \
-    unzip -qq PyFR-1.8.0.zip && \
-    cd PyFR-1.8.0 && \
+# Install PyFR 1.9.0
+RUN wget -q -O PyFR-1.9.0.zip https://github.com/PyFR/PyFR/archive/v1.9.0.zip && \
+    unzip -qq PyFR-1.9.0.zip && \
+    cd PyFR-1.9.0 && \
     python3 setup.py install && \
     cd /
 
-RUN chown -R celery  /PyFR-1.8.0
+RUN chown -R celery  /PyFR-1.9.0

--- a/docker/compute-parflow/Dockerfile
+++ b/docker/compute-parflow/Dockerfile
@@ -40,13 +40,13 @@ ENV HYPRE_DIR=/hypre
 ENV PARFLOW_DIR=/parflow
 
 # Install hypre
-RUN wget -q https://github.com/hypre-space/hypre/archive/v2.17.0.tar.gz && \
-    tar xf v2.17.0.tar.gz && \
-    cd hypre-2.17.0/src && \
+RUN wget -q https://github.com/hypre-space/hypre/archive/v2.18.2.tar.gz && \
+    tar xf v2.18.2.tar.gz && \
+    cd hypre-2.18.2/src && \
     ./configure --prefix=/hypre --with-MPI && \
     make install && \
     cd / && \
-    rm -fr hypre-2.17.0 v2.17.0.tar.gz
+    rm -fr hypre-2.18.2 v2.18.2.tar.gz
 
 # Intall parflow
 RUN git clone -b master --single-branch https://github.com/parflow/parflow.git /parflow-tmp

--- a/docker/compute-pyfr/Dockerfile
+++ b/docker/compute-pyfr/Dockerfile
@@ -1,11 +1,11 @@
-# Docker file for compute PyFR 1.8.0
+# Docker file for compute PyFR 1.9.0
 
 ARG BASE_IMAGE=kitware/hpccloud:sge-ssh
 
 FROM ${BASE_IMAGE}
 LABEL maintainer="patrick.oleary@kitware.com" \
       version="1.0" \
-      pyfr.version="1.8.0"
+      pyfr.version="1.9.0"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -36,8 +36,8 @@ RUN pip3 install appdirs \
                  mpi4py \
                  h5py
 
-# Install PyFR 1.8.0
-RUN wget -q -O PyFR-1.8.0.zip https://github.com/PyFR/PyFR/archive/v1.8.0.zip && \
-    unzip -qq PyFR-1.8.0.zip && \
-    cd PyFR-1.8.0 && \
+# Install PyFR 1.9.0
+RUN wget -q -O PyFR-1.9.0.zip https://github.com/PyFR/PyFR/archive/v1.9.0.zip && \
+    unzip -qq PyFR-1.9.0.zip && \
+    cd PyFR-1.9.0 && \
     python3 setup.py install

--- a/docker/girder/Dockerfile
+++ b/docker/girder/Dockerfile
@@ -1,4 +1,4 @@
-FROM girder/girder:latest-py3
+FROM girder/girder:latest
 LABEL maintainer="patrick.oleary@kitware.com" \
       version="1.0"
 

--- a/docker/visualize-egl/Dockerfile
+++ b/docker/visualize-egl/Dockerfile
@@ -1,10 +1,10 @@
-# Docker file for visualize EGL ParaView 5.6.0
+# Docker file for visualize EGL ParaView 5.8.0
 #
 # Build options
 #
 #   PARAVIEW_TAG
 #
-#     "master", "v5.6.0", <branch-name>, etc...
+#     "master", "v5.8.0", <branch-name>, etc...
 #
 #   SUPERBUILD_REPO
 #
@@ -12,17 +12,17 @@
 #
 #   SUPERBUILD_TAG
 #
-#     "master", "v5.6.0", <branch-name>, etc...
+#     "master", "v5.8.0", <branch-name>, etc...
 #
 
 FROM kitware/hpccloud:nvidia-sge-ssh
 
 LABEL maintainer="patrick.oleary@kitware.com" \
       version="1.0" \
-      ParaView.version="5.6.0"
+      ParaView.version="5.8.0"
 
-ARG PARAVIEW_TAG=v5.7.0-RC1
-ARG SUPERBUILD_TAG=v5.7.0-RC1
+ARG PARAVIEW_TAG=v5.8.0
+ARG SUPERBUILD_TAG=v5.8.0
 ARG SUPERBUILD_REPO=https://gitlab.kitware.com/paraview/paraview-superbuild.git
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Mongodb 3.6 -> 4.2 (girder recommends 4.2)
hypre 2.17.0 -> 2.18.2 (celery-parflow and compute-parflow)
PyFR 1.8.0 -> 1.9.0 (celery-pyfr and compute-pyfr)
ParaView 5.7.0-RC1 -> 5.8.0 (visualize-egl)

All of the above were briefly tested (except for parflow), and they
seem to work.

Planned updates:

~~node 10 -> 13 (nginx)~~
ParaView 5.6.1 -> 5.8.0 (visualize-osmesa)

~~The planned updates were not yet updated because updgrading nginx is
causing some compile issues with node-sass or node-gyp.~~ Upgrading
paraview for visualize-osmesa causes the visualization job to complete
immediately and does not allow the user to visualize the data.

Additionally, ["latest-py3" is no longer supported in girder](https://discourse.girder.org/t/dropping-python-2-support/317/4).
Instead, "latest" is now python3, and python2 is no longer supported.
This PR uses "latest" instead of "latest-py3".

Update: we are skipping upgrading node 10 to node 13 for nginx, because we will be using a new client in the near future anyways.