### PR TITLE
Allow docker to be ran in sge images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
     hostname: compute
     volumes:
      - scratch.hc:/scratch
+     - /var/run/docker.sock:/var/run/docker.sock:rw
     networks:
       - hc
     ports:

--- a/docker/sge-ssh/Dockerfile
+++ b/docker/sge-ssh/Dockerfile
@@ -17,7 +17,8 @@ ENV SGEMASTER=sge-master
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         openssh-client \
-        openssh-server && \
+        openssh-server \
+        curl && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /var/run/sshd && \
@@ -67,6 +68,14 @@ EXPOSE 22
 EXPOSE 6444
 EXPOSE 6445
 EXPOSE 6446
+
+# Download the docker client and set it up
+ENV DOCKERVERSION=18.03.1-ce
+RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \
+  && tar xzvf docker-${DOCKERVERSION}.tgz --strip 1 \
+                 -C /usr/local/bin docker/docker \
+  && rm docker-${DOCKERVERSION}.tgz \
+  && groupadd docker
 
 RUN useradd -p $(openssl passwd -1 letmein) --create-home --shell /bin/bash --groups sudo demo
 USER demo

--- a/docker/sge-ssh/entrypoint.sh
+++ b/docker/sge-ssh/entrypoint.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+# Setup docker group
+DOCKER_SOCKET=/var/run/docker.sock
+DOCKER_GROUP=docker
+
+if [ -S ${DOCKER_SOCKET} ]; then
+   DOCKER_GID=$(stat -c '%g' ${DOCKER_SOCKET})
+   groupmod -g ${DOCKER_GID} ${DOCKER_GROUP}
+   usermod -aG ${DOCKER_GROUP} demo
+fi
+
 if [ "$HOSTNAME" != "$SGEMASTER" ]; then
    echo "++++++++++++++++++++++Configuring SGE with new Master++++++++++++++++++++++++++++"
    echo "$HOSTNAME" >  /var/lib/gridengine/default/common/act_qmaster


### PR DESCRIPTION
These are the changes required to run docker in the local sge cluster images.

The changes in this PR are summarized as follows:

1. Download and install the docker client inside the sge image.
2. Add "demo" to the docker group so it has the needed permissions.
3. Mount the host docker socket inside the container.

These changes allow the "demo" user to run docker containers on the host
machine (they are "sibling" containers rather than "child" containers).

If we wish to run singularity on the demo cluster as well, we need only
to install singularity on the cluster image.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>