### PR TITLE
Add singularity to our slurm cluster

### DIFF
--- a/docker-compose-nvidia.yml
+++ b/docker-compose-nvidia.yml
@@ -13,6 +13,7 @@ services:
         - BASE_IMG=kitware/hpccloud:nvidia-slurm-ssh
     hostname: compute
     runtime: nvidia
+    privileged: true
     volumes:
      - scratch.hc:/scratch
     networks:
@@ -30,6 +31,7 @@ services:
         - SUPERBUILD_TAG=v5.6.1
     hostname: visualize
     runtime: nvidia
+    privileged: true
     volumes:
      - scratch.hc:/scratch
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,7 @@ services:
       context: .
       dockerfile: docker/compute-pyfr/Dockerfile
     hostname: compute
+    privileged: true
     volumes:
      - scratch.hc:/scratch
      - /var/run/docker.sock:/var/run/docker.sock:rw
@@ -128,6 +129,7 @@ services:
       context: .
       dockerfile: docker/visualize-osmesa/Dockerfile
     hostname: visualize
+    privileged: true
     volumes:
      - scratch.hc:/scratch
     networks:

--- a/docker/slurm-ssh/Dockerfile
+++ b/docker/slurm-ssh/Dockerfile
@@ -4,13 +4,11 @@ ARG BASE_IMAGE=kitware/hpccloud:bionic-python
 # slurm section #
 #################
 FROM ${BASE_IMAGE} as slurm
-LABEL maintainer="patrick.avery@kitware.com" \
-      version="1.0"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       slurm-wlm && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 # Make a directory for slurm spool
 RUN mkdir /var/spool/slurm-llnl && chown -R slurm:slurm /var/spool/slurm-llnl
@@ -24,28 +22,17 @@ ENTRYPOINT /entrypoint.sh
 #########################################
 # ssh section, with the demo user added #
 #########################################
-FROM slurm
-LABEL maintainer="patrick.avery@kitware.com" \
-      version="1.0"
+FROM slurm as slurm-ssh
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        openssh-client \
-        openssh-server \
-        curl && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+      openssh-client \
+      openssh-server && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /var/run/sshd && \
     chmod 0755 /var/run/sshd && \
     sed -ri 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
-
-# Download the docker client and set it up
-ENV DOCKERVERSION=18.03.1-ce
-RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \
-  && tar xzvf docker-${DOCKERVERSION}.tgz --strip 1 \
-                 -C /usr/local/bin docker/docker \
-  && rm docker-${DOCKERVERSION}.tgz \
-  && groupadd docker
 
 RUN useradd -p $(openssl passwd -1 letmein) --create-home --shell /bin/bash --groups sudo demo
 USER demo
@@ -64,3 +51,68 @@ COPY docker/slurm-ssh/supervisord.conf /etc/supervisord.conf
 
 ENTRYPOINT  ["/entrypoint.sh"]
 CMD ["/usr/local/bin/supervisord", "-c", "/etc/supervisord.conf"]
+
+##################
+# docker section #
+##################
+FROM slurm-ssh as slurm-docker
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download the docker client and set it up
+ENV DOCKERVERSION=18.03.1-ce
+RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \
+  && tar xzvf docker-${DOCKERVERSION}.tgz --strip 1 \
+                 -C /usr/local/bin docker/docker \
+  && rm docker-${DOCKERVERSION}.tgz \
+  && groupadd docker
+
+#######################
+# singularity section #
+#######################
+FROM slurm-docker
+LABEL maintainer="patrick.avery@kitware.com" \
+      version="1.0"
+
+# Set up timezone info for singularity
+ENV TZ=US/Eastern
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      libssl-dev \
+      uuid-dev \
+      libgpgme11-dev \
+      squashfs-tools \
+      libseccomp-dev \
+      wget \
+      pkg-config \
+      git \
+      cryptsetup \
+      tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN export VERSION=1.13 OS=linux ARCH=amd64 && \
+    wget -q https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
+    tar -C /usr/local -xzf go$VERSION.$OS-$ARCH.tar.gz && \
+    rm go$VERSION.$OS-$ARCH.tar.gz
+
+ENV GOPATH /go
+
+ENV PATH /usr/local/go/bin:${PATH}:${GOPATH}/bin
+
+RUN export VERSION=3.5.3 && \
+    mkdir -p /go/src/github.com/sylabs && \
+    cd /go/src/github.com/sylabs && \
+    wget -q https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+    tar -xzf singularity-${VERSION}.tar.gz && \
+    cd ./singularity && \
+    ./mconfig
+
+RUN cd /go/src/github.com/sylabs/singularity/builddir/ && \
+    make && \
+    make install


### PR DESCRIPTION
This adds singularity to our slurm cluster, with which you can build/pull
singularity images, and then run them.

Here is an example of using it:

    # Start up the cluster:
    docker-compose up

    # In a separate terminal copy the parflow test directory to the compute-pyfr docker container
    docker cp test <id>:/home/demo/

    # Enter into the compute-pyfr container
    docker exec -u demo -w /home/demo/test -it <id> bash

    # Build the singularity image. The docker image must be present locally on your computer.
    # This image comes from https://github.com/Kitware/hpccloud-services/pull/14
    singularity build parflow.sif docker-daemon:kitware/hpccloud:parflow

    # Run a test
    singularity run ./parflow.sif default_overland.tcl 1 1 1
    # default_overland : PASSED

Note: the cluster images must be ran in "privileged" mode in order
to use singularity on them. That is being done in the docker-compose files
now.